### PR TITLE
Added win-x86 to nuget

### DIFF
--- a/.github/workflows/package_main.yml
+++ b/.github/workflows/package_main.yml
@@ -41,6 +41,9 @@ jobs:
     - name: Set Dev Version
       run: echo "PACKAGE_VERSION=1.0.0-dev.${{ GITHUB.RUN_NUMBER }}" >> $env:GITHUB_ENV
 
+    - name: Build
+      run: dotnet build src/FileOnQ.Imaging.Raw/FileOnQ.Imaging.Raw.csproj -c Release
+
     - name: Pack
       run: dotnet pack src/FileOnQ.Imaging.Raw/FileOnQ.Imaging.Raw.csproj -c Release -o . /p:Version=${{ env.PACKAGE_VERSION }} /p:PackageVersion=${{ env.PACKAGE_VERSION }}
 

--- a/.github/workflows/package_pr.yml
+++ b/.github/workflows/package_pr.yml
@@ -41,6 +41,9 @@ jobs:
     - name: Set PR Version
       run: echo "PACKAGE_VERSION=1.0.0-pr.${{ GITHUB.RUN_NUMBER }}" >> $env:GITHUB_ENV
         
+    - name: Build
+      run: dotnet build src/FileOnQ.Imaging.Raw/FileOnQ.Imaging.Raw.csproj -c Release
+    
     - name: Pack
       run: dotnet pack src/FileOnQ.Imaging.Raw/FileOnQ.Imaging.Raw.csproj -c Release -o . /p:Version=${{ env.PACKAGE_VERSION }} /p:PackageVersion=${{ env.PACKAGE_VERSION }}
 

--- a/src/FileOnQ.Imaging.Raw/Build/nuget.props
+++ b/src/FileOnQ.Imaging.Raw/Build/nuget.props
@@ -29,12 +29,6 @@
 		<None Include="$(RootDir)\images\fileonq.png" Pack="true" PackagePath="" />
 	</ItemGroup>
 
-	<!-- NOTE - 8/3/2021 - @ahoefling - This copies all dlls to output folder so direct project references work. Without this the regular unit tests will fail. However, when the project
-	            reference is using NuGet instead of direct project reference the dlls can be placed in the runtimes/**/native folder for net5+. -->
-	<ItemGroup>
-		<None Include="*.dll" CopyToOutputDirectory="Always" />
-	</ItemGroup>
-
 	<ItemGroup>
 		<!-- Copy all win-x86 native binaries -->
 		<Content Include="*32.dll" Pack="True" PackagePath="runtimes\win-x86\native\" Link="runtimes\win-x86\native\%(Filename)%(Extension)" CopyToOutputDirectory="Always" />
@@ -44,6 +38,12 @@
 		<Content Include="FileOnQ.Imaging.Raw.Gpu.Cuda.dll" Pack="True" PackagePath="runtimes\win-x64\native" Link="runtimes\win-x64\native\%(Filename)%(Extension)" CopyToOutputDirectory="Always" />
 	</ItemGroup>
 
+	<!-- NOTE - 8/3/2021 - @ahoefling - This copies all dlls to output folder so direct project references work. Without this the regular unit tests will fail. However, when the project
+	            reference is using NuGet instead of direct project reference the dlls can be placed in the runtimes/**/native folder for net5+. -->
+	<ItemGroup>
+		<None Include="*.dll" CopyToOutputDirectory="Always" />
+	</ItemGroup>
+	
 	<!-- Adds targets to NuGet which runs additional targets downstream. These targets are used for copying native dlls from the package to the bin directory -->
 	<ItemGroup>
 		<Content Include="Build\FileOnQ.Imaging.Raw.targets" Pack="true" PackagePath="build\net48" />

--- a/src/FileOnQ.Imaging.Raw/Build/nuget.props
+++ b/src/FileOnQ.Imaging.Raw/Build/nuget.props
@@ -29,6 +29,12 @@
 		<None Include="$(RootDir)\images\fileonq.png" Pack="true" PackagePath="" />
 	</ItemGroup>
 
+	<!-- NOTE - 8/3/2021 - @ahoefling - This copies all dlls to output folder so direct project references work. Without this the regular unit tests will fail. However, when the project
+	            reference is using NuGet instead of direct project reference the dlls can be placed in the runtimes/**/native folder for net5+. -->
+	<ItemGroup>
+		<None Include="*.dll" CopyToOutputDirectory="Always" />
+	</ItemGroup>
+
 	<ItemGroup>
 		<!-- Copy all win-x86 native binaries -->
 		<Content Include="*32.dll" Pack="True" PackagePath="runtimes\win-x86\native\" Link="runtimes\win-x86\native\%(Filename)%(Extension)" CopyToOutputDirectory="Always" />
@@ -36,12 +42,6 @@
 		<!-- Copy all win-x64 native binaries -->
 		<Content Include="libraw.dll" Pack="True" PackagePath="runtimes\win-x64\native" Link="runtimes\win-x64\native\%(Filename)%(Extension)" CopyToOutputDirectory="Always" />
 		<Content Include="FileOnQ.Imaging.Raw.Gpu.Cuda.dll" Pack="True" PackagePath="runtimes\win-x64\native" Link="runtimes\win-x64\native\%(Filename)%(Extension)" CopyToOutputDirectory="Always" />
-	</ItemGroup>
-
-	<!-- NOTE - 8/3/2021 - @ahoefling - This copies all dlls to output folder so direct project references work. Without this the regular unit tests will fail. However, when the project
-	            reference is using NuGet instead of direct project reference the dlls can be placed in the runtimes/**/native folder for net5+. -->
-	<ItemGroup>
-		<None Include="*.dll" CopyToOutputDirectory="Always" />
 	</ItemGroup>
 
 	<!-- Adds targets to NuGet which runs additional targets downstream. These targets are used for copying native dlls from the package to the bin directory -->

--- a/src/FileOnQ.Imaging.Raw/Build/nuget.props
+++ b/src/FileOnQ.Imaging.Raw/Build/nuget.props
@@ -43,7 +43,7 @@
 	<ItemGroup>
 		<None Include="*.dll" CopyToOutputDirectory="Always" />
 	</ItemGroup>
-	
+
 	<!-- Adds targets to NuGet which runs additional targets downstream. These targets are used for copying native dlls from the package to the bin directory -->
 	<ItemGroup>
 		<Content Include="Build\FileOnQ.Imaging.Raw.targets" Pack="true" PackagePath="build\net48" />


### PR DESCRIPTION
Fixes: #4 

Adds `win-x86` to the `runtimes` folder for the deployed NuGet. To solve this we needed to add `dotnet build` prior to `dotnet pack` in both the PR package and main package github actions