### PR TITLE
Changes dll Names for LibRaw Fork

### DIFF
--- a/src/FileOnQ.Imaging.Raw/Build/FileOnQ.Imaging.Raw.targets
+++ b/src/FileOnQ.Imaging.Raw/Build/FileOnQ.Imaging.Raw.targets
@@ -2,9 +2,9 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
 	<Target Name="CopyNativeDlls" BeforeTargets="Build">
-		<Copy SourceFiles="$(MSBuildThisFileDirectory)..\..\runtimes\win-x64\native\libraw.dll" DestinationFolder="$(ProjectDir)\$(OutDir)" />
+		<Copy SourceFiles="$(MSBuildThisFileDirectory)..\..\runtimes\win-x64\native\libraw_fileonq.dll" DestinationFolder="$(ProjectDir)\$(OutDir)" />
 		<Copy SourceFiles="$(MSBuildThisFileDirectory)..\..\runtimes\win-x64\native\FileOnQ.Imaging.Raw.Gpu.Cuda.dll" DestinationFolder="$(ProjectDir)\$(OutDir)" />
-		<Copy SourceFiles="$(MSBuildThisFileDirectory)..\..\runtimes\win-x86\native\libraw32.dll" DestinationFolder="$(ProjectDir)\$(OutDir)" />
+		<Copy SourceFiles="$(MSBuildThisFileDirectory)..\..\runtimes\win-x86\native\libraw_fileonq32.dll" DestinationFolder="$(ProjectDir)\$(OutDir)" />
 		<Copy SourceFiles="$(MSBuildThisFileDirectory)..\..\runtimes\win-x86\native\FileOnQ.Imaging.Raw.Gpu.Cuda32.dll" DestinationFolder="$(ProjectDir)\$(OutDir)" />
 	</Target>
 

--- a/src/FileOnQ.Imaging.Raw/Build/cpp-build.targets
+++ b/src/FileOnQ.Imaging.Raw/Build/cpp-build.targets
@@ -7,17 +7,17 @@
 
 	<!-- NOTE - 7/30/2021 - @ahoefling - Only build LibRaw if it is a rebuild or clean. The binaries take a long time to compile and don't change often -->
 	<!-- NOTE - 7/30/2021 - @ahoefling - This build target only works with MSBuild through Visual Studio-->
-	<Target Name="LibRaw" BeforeTargets="DispatchToInnerBuilds" Condition="!Exists('libraw32.dll') and !Exists('libraw.dll')">
+	<Target Name="LibRaw" BeforeTargets="DispatchToInnerBuilds" Condition="!Exists('libraw_fileonq32.dll') and !Exists('libraw_fileonq.dll')">
 		<Exec Command="libraw.bat x64" WorkingDirectory="$(RootDir)/build" />
-		<Copy SourceFiles="$(RootDir)/LibRaw/bin/libraw.dll" DestinationFolder="." />
+		<Copy SourceFiles="$(RootDir)/LibRaw/bin/libraw_fileonq.dll" DestinationFolder="." />
 
 		<Exec Command="libraw.bat x86" WorkingDirectory="$(RootDir)/build" />
-		<Copy SourceFiles="$(RootDir)/LibRaw/bin/libraw32.dll" DestinationFolder="." />
+		<Copy SourceFiles="$(RootDir)/LibRaw/bin/libraw_fileonq32.dll" DestinationFolder="." />
 	</Target>
 
 	<Target Name="CleanLibRaw" BeforeTargets="Clean">
-		<Delete Files="libraw.dll" />
-		<Delete Files="libraw32.dll" />
+		<Delete Files="libraw_fileonq.dll" />
+		<Delete Files="libraw_fileonq32.dll" />
 	</Target>
 
 	<!-- NOTE 7/30/2021 - @ahoefling - Building the GPU binaries on every build ensures the latest kernels are included with each build -->

--- a/src/FileOnQ.Imaging.Raw/Build/nuget.props
+++ b/src/FileOnQ.Imaging.Raw/Build/nuget.props
@@ -34,7 +34,7 @@
 		<Content Include="*32.dll" Pack="True" PackagePath="runtimes\win-x86\native\" Link="runtimes\win-x86\native\%(Filename)%(Extension)" CopyToOutputDirectory="Always" />
 
 		<!-- Copy all win-x64 native binaries -->
-		<Content Include="libraw.dll" Pack="True" PackagePath="runtimes\win-x64\native" Link="runtimes\win-x64\native\%(Filename)%(Extension)" CopyToOutputDirectory="Always" />
+		<Content Include="libraw_fileonq.dll" Pack="True" PackagePath="runtimes\win-x64\native" Link="runtimes\win-x64\native\%(Filename)%(Extension)" CopyToOutputDirectory="Always" />
 		<Content Include="FileOnQ.Imaging.Raw.Gpu.Cuda.dll" Pack="True" PackagePath="runtimes\win-x64\native" Link="runtimes\win-x64\native\%(Filename)%(Extension)" CopyToOutputDirectory="Always" />
 	</ItemGroup>
 

--- a/src/FileOnQ.Imaging.Raw/LibRaw/NativeApi_x64.cs
+++ b/src/FileOnQ.Imaging.Raw/LibRaw/NativeApi_x64.cs
@@ -7,7 +7,7 @@ namespace FileOnQ.Imaging.Raw
 	{
 		private static unsafe class X64
 		{
-			const string DllName = "libraw.dll";
+			const string DllName = "libraw_fileonq.dll";
 
 			[DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
 			internal static extern IntPtr libraw_init(uint flags);

--- a/src/FileOnQ.Imaging.Raw/LibRaw/NativeApi_x86.cs
+++ b/src/FileOnQ.Imaging.Raw/LibRaw/NativeApi_x86.cs
@@ -7,7 +7,7 @@ namespace FileOnQ.Imaging.Raw
 	{
 		private static unsafe class X86
 		{
-			const string DllName = "libraw32.dll";
+			const string DllName = "libraw_fileonq32.dll";
 
 			[DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
 			internal static extern IntPtr libraw_init(uint flags);


### PR DESCRIPTION
## Description
Since this library is using a custom compiled version of LibRaw, it needs to compile these dependencies so they don't conflict with other versions of the library. The easiest way to do this is create a custom name for the dlls. This PR changes the submodules compile instructions to generate the following dlls
* libraw_fileonq.dll
* libraw_fileonq32.dll

Fixes: #14 