### PR TITLE
Updates NuGet Package - SourceLink, Deterministic & SDK

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -111,7 +111,7 @@ jobs:
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.102
+        dotnet-version: 5.0.302
 
     - name: Setup NuGet.exe
       uses: NuGet/setup-nuget@v1.0.5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.102
+        dotnet-version: 5.0.302
 
     - name: Setup NuGet.exe
       uses: NuGet/setup-nuget@v1.0.5

--- a/.github/workflows/build_libraw.yml
+++ b/.github/workflows/build_libraw.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.102
+        dotnet-version: 5.0.302
 
     - name: Setup NuGet.exe
       uses: NuGet/setup-nuget@v1.0.5

--- a/.github/workflows/package_main.yml
+++ b/.github/workflows/package_main.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.102
+        dotnet-version: 5.0.302
 
     - name: Setup NuGet.exe
       uses: NuGet/setup-nuget@v1.0.5

--- a/.github/workflows/package_main.yml
+++ b/.github/workflows/package_main.yml
@@ -45,7 +45,7 @@ jobs:
       run: dotnet build src/FileOnQ.Imaging.Raw/FileOnQ.Imaging.Raw.csproj -c Release
 
     - name: Pack
-      run: dotnet pack src/FileOnQ.Imaging.Raw/FileOnQ.Imaging.Raw.csproj -c Release -o . /p:Version=${{ env.PACKAGE_VERSION }} /p:PackageVersion=${{ env.PACKAGE_VERSION }}
+      run: dotnet pack src/FileOnQ.Imaging.Raw/FileOnQ.Imaging.Raw.csproj -c Release -o . /p:ContinuousIntegrationBuild=true /p:Version=${{ env.PACKAGE_VERSION }} /p:PackageVersion=${{ env.PACKAGE_VERSION }}
 
     - name: Upload NuGet Package
       uses: actions/upload-artifact@v2

--- a/.github/workflows/package_pr.yml
+++ b/.github/workflows/package_pr.yml
@@ -45,7 +45,7 @@ jobs:
       run: dotnet build src/FileOnQ.Imaging.Raw/FileOnQ.Imaging.Raw.csproj -c Release
     
     - name: Pack
-      run: dotnet pack src/FileOnQ.Imaging.Raw/FileOnQ.Imaging.Raw.csproj -c Release -o . /p:Version=${{ env.PACKAGE_VERSION }} /p:PackageVersion=${{ env.PACKAGE_VERSION }}
+      run: dotnet pack src/FileOnQ.Imaging.Raw/FileOnQ.Imaging.Raw.csproj -c Release -o . /p:ContinuousIntegrationBuild=true /p:Version=${{ env.PACKAGE_VERSION }} /p:PackageVersion=${{ env.PACKAGE_VERSION }}
 
     - name: Upload NuGet Package
       uses: actions/upload-artifact@v2

--- a/.github/workflows/package_pr.yml
+++ b/.github/workflows/package_pr.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.102
+        dotnet-version: 5.0.302
 
     - name: Setup NuGet.exe
       uses: NuGet/setup-nuget@v1.0.5

--- a/src/FileOnQ.Imaging.Raw/Build/nuget.props
+++ b/src/FileOnQ.Imaging.Raw/Build/nuget.props
@@ -17,6 +17,8 @@
 		<License>LGPL</License>
 		<RepositoryUrl>https://github.com/FileOnQ/Imaging.Raw</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
+		<PublishRepositoryUrl>true</PublishRepositoryUrl>
+		<EmbedUntrackedSources>true</EmbedUntrackedSources>
 		<!-- End NuGet Package Properties -->
 		
 		<!-- Start NuGet Symbols Package Properties -->
@@ -25,10 +27,15 @@
 		<!-- End1 NuGet Symbols Package Properties -->
 	</PropertyGroup>
 
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+	</ItemGroup>
+
 	<ItemGroup>
 		<None Include="$(RootDir)\images\fileonq.png" Pack="true" PackagePath="" />
 	</ItemGroup>
-
+	
 	<ItemGroup>
 		<!-- Copy all win-x86 native binaries -->
 		<Content Include="*32.dll" Pack="True" PackagePath="runtimes\win-x86\native\" Link="runtimes\win-x86\native\%(Filename)%(Extension)" CopyToOutputDirectory="Always" />


### PR DESCRIPTION
## Description
Ensures the NuGet package is build to support:
* SourceLink
* Deterministic Build
* Compiled under latest .NET SDK

## Problem
If you navigate to the current pre-release NuGet package you will see that there are some NuGet warnings for the items fixed above.
* https://nuget.info/packages/FileOnQ.Imaging.Raw/1.0.0-dev.11

![image](https://user-images.githubusercontent.com/17751436/128878547-980e7da4-39d2-4199-a6c3-3dde59f93a20.png)

## Testing
I have created a local NuGet package and opened it in the NuGet Package Explorer. Everything appears to look correctly, but we will need to do the same with the generated NuGet from the PR build to confirm.

![image](https://user-images.githubusercontent.com/17751436/128879087-2a5b2b84-b37f-43df-808e-7b02e75b86b9.png)
