### PR TITLE
automate finding vcvarsall to support more vs versions

### DIFF
--- a/build/libraw.bat
+++ b/build/libraw.bat
@@ -1,7 +1,14 @@
 @echo off
 title Building LibRaw
 set arch=%1
-call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" %arch%
+for /f "usebackq tokens=1* delims=" %%x in (`vswhere -find **\vcvarsall.bat`) do set vcvar="%%~x"
+
+if not defined vcvar (
+	echo "unable to find 'vcvarsall.bat'. visual studio c++ package needs to be installed"
+	exit /b 2
+)
+
+call %vcvar% %arch%
 cd ../LibRaw
 
 git clean -xd -f lib -f bin -f object


### PR DESCRIPTION
<!-- link your pull request to an open issue -->
Fixes: #1 

## Description
<!-- Describe your change in a 1-5 sentences -->
Changing the hardcoded path for vcvarall.bat to be found automatically to avoid dependencies of vs versions. This should add support for multiple versions and editions of visual studio

## Merge Checklist
- [ ] Added unit or integration tests (if not explain)
- [ ] Benchmarks are equivalent or faster