### PR TITLE
Change vswhere call to use full path

### DIFF
--- a/build/libraw.bat
+++ b/build/libraw.bat
@@ -3,10 +3,9 @@ title Building LibRaw
 set arch=%1
 set vcvar=
 
-for /f "usebackq tokens=1* delims=" %%x in ("%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe" -find **\vcvarsall.bat) do set vcvar="%%~x"
+for /f "usebackq tokens=1* delims=" %%x in (`"%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe" -find **\vcvarsall.bat`) do set vcvar="%%~x"
 
-if not defined vcvar (	
-	pause
+if defined ProgramFiles(x86) if not defined vcvar (
 	for /f "usebackq tokens=1* delims=" %%x in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -find **\vcvarsall.bat`) do set vcvar="%%~x"
 )
 

--- a/build/libraw.bat
+++ b/build/libraw.bat
@@ -2,17 +2,37 @@
 title Building LibRaw
 set arch=%1
 set vcvar=
-
-set progFiles="%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe"
-for /f "usebackq tokens=1 delims=" %%x in (`"%progFiles%" -find **\vcvarsall.bat`) do set vcvar="%%~x"
-
-if defined vcvar goto fileFound
+set progFile=
 
 
-if not defined ProgramFiles(x86) goto fileNotFound
+::check default 
+set vswhereFile="%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe"
+if exist %vswhereFile% (	
+	goto setprogfile
+)
+goto check86
 
 
-for /f "usebackq tokens=1 delims=" %%y in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -find **\vcvarsall.bat`) do set vcvar="%%~y"
+
+:setprogfile
+set progFile=%ProgramFiles%
+goto vswhereFound
+
+
+
+:check86
+set vswhereFile86="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+if exist "%vswhereFile86%" (
+	set progFile=%vswhereFile86%
+	goto vswhereFound
+)
+goto fileNotFound
+
+
+
+:vswhereFound
+set vcvar=
+for /f "usebackq tokens=1 delims=" %%x in (`%progFile% -find **\vcvarsall.bat`) do set vcvar="%%~x"
 if defined vcvar goto fileFound
 
 

--- a/build/libraw.bat
+++ b/build/libraw.bat
@@ -1,4 +1,4 @@
-::@echo off
+@echo off
 title Building LibRaw
 set arch=%1
 set vcvar=

--- a/build/libraw.bat
+++ b/build/libraw.bat
@@ -1,9 +1,16 @@
 @echo off
 title Building LibRaw
 set arch=%1
-for /f "usebackq tokens=1* delims=" %%x in (`vswhere -find **\vcvarsall.bat`) do set vcvar="%%~x"
+set vcvar=
 
-if not defined vcvar (
+for /f "usebackq tokens=1* delims=" %%x in ("%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe" -find **\vcvarsall.bat) do set vcvar="%%~x"
+
+if not defined vcvar (	
+	pause
+	for /f "usebackq tokens=1* delims=" %%x in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -find **\vcvarsall.bat`) do set vcvar="%%~x"
+)
+
+if not defined vcvar (	
 	echo "unable to find 'vcvarsall.bat'. visual studio c++ package needs to be installed"
 	exit /b 2
 )

--- a/build/libraw.bat
+++ b/build/libraw.bat
@@ -44,7 +44,7 @@ exit /b 2
 
 
 :fileFound
-echo "csvarsall.bat was found, continuing"
+echo "vcvarsall.bat was found, continuing"
 
 call %vcvar% %arch%
 cd ../LibRaw

--- a/build/libraw.bat
+++ b/build/libraw.bat
@@ -1,18 +1,30 @@
-@echo off
+::@echo off
 title Building LibRaw
 set arch=%1
 set vcvar=
 
-for /f "usebackq tokens=1* delims=" %%x in (`"%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe" -find **\vcvarsall.bat`) do set vcvar="%%~x"
+set progFiles="%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe"
+for /f "usebackq tokens=1 delims=" %%x in (`"%progFiles%" -find **\vcvarsall.bat`) do set vcvar="%%~x"
 
-if defined ProgramFiles(x86) if not defined vcvar (
-	for /f "usebackq tokens=1* delims=" %%x in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -find **\vcvarsall.bat`) do set vcvar="%%~x"
-)
+if defined vcvar goto fileFound
 
-if not defined vcvar (	
-	echo "unable to find 'vcvarsall.bat'. visual studio c++ package needs to be installed"
-	exit /b 2
-)
+
+if not defined ProgramFiles(x86) goto fileNotFound
+
+
+for /f "usebackq tokens=1 delims=" %%y in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -find **\vcvarsall.bat`) do set vcvar="%%~y"
+if defined vcvar goto fileFound
+
+
+
+:fileNotFound
+echo "unable to find 'vcvarsall.bat'. visual studio c++ package needs to be installed"
+exit /b 2
+
+
+
+:fileFound
+echo "csvarsall.bat was found, continuing"
 
 call %vcvar% %arch%
 cd ../LibRaw


### PR DESCRIPTION
## Description
<!-- Describe your change in a 1-5 sentences -->
Changes call to vswhere to a full path to avoid needing to install it.
Checks normal path then x86

this is to extend the change done in #34 